### PR TITLE
Interface adapter tests

### DIFF
--- a/src/use_case/Game/GameOverUseCase.java
+++ b/src/use_case/Game/GameOverUseCase.java
@@ -52,9 +52,8 @@ public class GameOverUseCase {
     }
 
     private int calculateFinalScore() {
-        // Implement your logic for calculating the final score here
+        // Implement logic for calculating the final score here
         // For example, you might sum up scores from different aspects of the game
-        // Replace this with your actual scoring logic
         return 0;
     }
 }

--- a/test/interface_adapter/CancelControllerTest.java
+++ b/test/interface_adapter/CancelControllerTest.java
@@ -1,0 +1,57 @@
+package interface_adapter;
+
+import interface_adapter.Login.LoginState;
+import interface_adapter.Login.LoginViewModel;
+import interface_adapter.Signup.SignupState;
+import interface_adapter.Signup.SignupViewModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.*;
+
+class CancelControllerTest {
+
+    @Mock
+    private SignupViewModel mockSignupViewModel;
+    @Mock
+    private LoginViewModel mockLoginViewModel;
+    @Mock
+    private ViewManagerModel mockViewManagerModel;
+
+    private CancelController cancelControllerForSignup;
+    private CancelController cancelControllerForLogin;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        cancelControllerForSignup = new CancelController(mockSignupViewModel, mockViewManagerModel);
+        cancelControllerForLogin = new CancelController(mockLoginViewModel, mockViewManagerModel);
+    }
+
+    @Test
+    void testCancelSignUp() {
+        SignupState mockSignupState = mock(SignupState.class);
+        when(mockSignupViewModel.getState()).thenReturn(mockSignupState);
+
+        cancelControllerForSignup.cancelSignUp();
+
+        verify(mockSignupState).setUsername(null);
+        verify(mockSignupViewModel).firePropertyChanged();
+        verify(mockViewManagerModel).setActiveView("the city game");
+        verify(mockViewManagerModel).firePropertyChanged();
+    }
+
+    @Test
+    void testCancelLogIn() {
+        LoginState mockLoginState = mock(LoginState.class);
+        when(mockLoginViewModel.getState()).thenReturn(mockLoginState);
+
+        cancelControllerForLogin.cancelLogIn();
+
+        verify(mockLoginState).setUsername(null);
+        verify(mockLoginViewModel).firePropertyChanged();
+        verify(mockViewManagerModel).setActiveView("the city game");
+        verify(mockViewManagerModel).firePropertyChanged();
+    }
+}

--- a/test/interface_adapter/ConsolePresenterTest.java
+++ b/test/interface_adapter/ConsolePresenterTest.java
@@ -41,4 +41,24 @@ public class ConsolePresenterTest {
         assertEquals(expectedOutput, outContent.toString());
     }
 
+    @Test
+    public void testDisplayFeedbackScoreAbove80() {
+        ConsolePresenter presenter = new ConsolePresenter();
+        presenter.displayFeedback(85);
+        assertEquals("You are awesome!\n", outContent.toString());
+    }
+
+    @Test
+    public void testDisplayFeedbackScoreAbove50() {
+        ConsolePresenter presenter = new ConsolePresenter();
+        presenter.displayFeedback(75);
+        assertEquals("You are good!\n", outContent.toString());
+    }
+
+    @Test
+    public void testDisplayFeedbackScoreBelow50() {
+        ConsolePresenter presenter = new ConsolePresenter();
+        presenter.displayFeedback(45);
+        assertEquals("You can do better!\n", outContent.toString());
+    }
 }

--- a/test/interface_adapter/ConsolePresenterTest.java
+++ b/test/interface_adapter/ConsolePresenterTest.java
@@ -1,0 +1,44 @@
+package interface_adapter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConsolePresenterTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterEach
+    public void restoreStreams() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    public void testDisplayMessage() {
+        ConsolePresenter presenter = new ConsolePresenter();
+        presenter.displayMessage("Test message");
+        assertEquals("Test message\n", outContent.toString());
+    }
+
+    @Test
+    public void testDisplayOptions() {
+        ConsolePresenter presenter = new ConsolePresenter();
+        presenter.displayOptions();
+        String expectedOutput = "Do you want to play again or quit?\n" +
+                "1. Play again\n" +
+                "2. Quit\n";
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+}

--- a/test/interface_adapter/LoginControllerTest.java
+++ b/test/interface_adapter/LoginControllerTest.java
@@ -1,0 +1,37 @@
+package interface_adapter;
+
+import interface_adapter.Login.LoginController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import use_case.Login.LoginInputBoundary;
+import use_case.Login.LoginInputData;
+
+import static org.mockito.Mockito.*;
+
+class LoginControllerTest {
+
+    private LoginInputBoundary loginInputBoundaryMock;
+    private LoginController loginController;
+
+    @BeforeEach
+    void setUp() {
+        // Mock the LoginInputBoundary
+        loginInputBoundaryMock = mock(LoginInputBoundary.class);
+        // Instantiate the LoginController with the mocked LoginInputBoundary
+        loginController = new LoginController(loginInputBoundaryMock);
+    }
+
+    @Test
+    void testExecute() {
+        // Given
+        String username = "testUser";
+        String password = "testPass";
+
+        // When
+        loginController.execute(username, password);
+
+        // Then
+        // Verify that the execute method of the mocked LoginInputBoundary is called with any instance of LoginInputData
+        verify(loginInputBoundaryMock).execute(any(LoginInputData.class));
+    }
+}

--- a/test/use_caseInteractor/GameInteractorTest.java
+++ b/test/use_caseInteractor/GameInteractorTest.java
@@ -97,7 +97,7 @@ public class GameInteractorTest {
         }
 
         @Override
-        public void hintView(GameOutputData data) {
+        public void hintView(GameOutputData data, int hint) {
             hintDisplayed = true;
         }
 
@@ -113,6 +113,11 @@ public class GameInteractorTest {
 
         @Override
         public void backToMain() {
+
+        }
+
+        @Override
+        public void returnToMain() {
 
         }
 

--- a/test/use_caseInteractor/GameMockTest.java
+++ b/test/use_caseInteractor/GameMockTest.java
@@ -46,15 +46,15 @@ public class GameMockTest {
         City testCity = new City("TestCity", null);
         GameInputData inputData = new GameInputData("", "2", testCity);
         String hint = "This is a hint";
-        int someIntValue = 0; // Replace with the appropriate int value expected by hintView
         when(client.getResponse(anyString())).thenReturn(hint);
         ArgumentCaptor<GameOutputData> captor = ArgumentCaptor.forClass(GameOutputData.class);
+        int expectedHintLevel = 2; // This should match the hint level in inputData
 
         // Act
         gameInteractor.executeHint(inputData);
 
         // Assert
-        verify(gameOutputBoundary).hintView(captor.capture(), eq(someIntValue));
+        verify(gameOutputBoundary).hintView(captor.capture(), eq(expectedHintLevel)); // Use eq() to specify the expected value
         assertEquals(hint, captor.getValue().getHint());
     }
 
@@ -120,4 +120,15 @@ public class GameMockTest {
         // Assert
         verify(gameOutputBoundary).backToMain();
     }
+
+    @Test
+    public void returnToMain() {
+        // Act
+        gameInteractor.returnToMain();
+
+        // Assert
+        verify(gameOutputBoundary).returnToMain();
+    }
 }
+
+

--- a/test/use_caseInteractor/GameMockTest.java
+++ b/test/use_caseInteractor/GameMockTest.java
@@ -48,14 +48,15 @@ public class GameMockTest {
         String hint = "This is a hint";
         when(client.getResponse(anyString())).thenReturn(hint);
         ArgumentCaptor<GameOutputData> captor = ArgumentCaptor.forClass(GameOutputData.class);
-        int expectedHintLevel = 2; // This should match the hint level in inputData
+        ArgumentCaptor<Integer> intCaptor = ArgumentCaptor.forClass(Integer.class);
 
         // Act
         gameInteractor.executeHint(inputData);
 
         // Assert
-        verify(gameOutputBoundary).hintView(captor.capture(), eq(expectedHintLevel)); // Use eq() to specify the expected value
+        verify(gameOutputBoundary).hintView(captor.capture(), intCaptor.capture());
         assertEquals(hint, captor.getValue().getHint());
+        assertEquals(Integer.valueOf(2), intCaptor.getValue()); // Ensure the second argument is 2
     }
 
     @Test

--- a/test/use_caseInteractor/GameMockTest.java
+++ b/test/use_caseInteractor/GameMockTest.java
@@ -46,6 +46,7 @@ public class GameMockTest {
         City testCity = new City("TestCity", null);
         GameInputData inputData = new GameInputData("", "2", testCity);
         String hint = "This is a hint";
+        int someIntValue = 0; // Replace with the appropriate int value expected by hintView
         when(client.getResponse(anyString())).thenReturn(hint);
         ArgumentCaptor<GameOutputData> captor = ArgumentCaptor.forClass(GameOutputData.class);
 
@@ -53,7 +54,7 @@ public class GameMockTest {
         gameInteractor.executeHint(inputData);
 
         // Assert
-        verify(gameOutputBoundary).hintView(captor.capture());
+        verify(gameOutputBoundary).hintView(captor.capture(), eq(someIntValue));
         assertEquals(hint, captor.getValue().getHint());
     }
 

--- a/test/use_caseInteractor/GuestInteractorTest.java
+++ b/test/use_caseInteractor/GuestInteractorTest.java
@@ -37,5 +37,9 @@ public class GuestInteractorTest {
         verify(guestOutputBoundary).prepareSuccessView(captor.capture());
         GuestOutputData outputData = captor.getValue();
 
+        // Since there are no getters in GuestOutputData, we cannot directly assert its state.
+        // We need to rely on the behavior of the GuestInteractor and the interactions with its dependencies.
+        // If the GuestInteractor is supposed to change the state of the system or call other methods,
+        // those interactions should be verified here.
     }
 }

--- a/test/use_caseInteractor/GuestInteractorTest.java
+++ b/test/use_caseInteractor/GuestInteractorTest.java
@@ -1,0 +1,27 @@
+package use_caseInteractor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import use_case.Guest.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class GuestInteractorTest {
+
+    private GuestUserDataAccessInterface userDataAccessObject;
+    private GuestOutputBoundary guestOutputBoundary;
+    private GuestInteractor guestInteractor;
+
+    @Before
+    public void setUp() {
+        // Mock the dependencies
+        userDataAccessObject = mock(GuestUserDataAccessInterface.class);
+        guestOutputBoundary = mock(GuestOutputBoundary.class);
+
+        // Initialize the GuestInteractor with the mocked dependencies
+        guestInteractor = new GuestInteractor(userDataAccessObject, guestOutputBoundary);
+    }
+
+}

--- a/test/use_caseInteractor/GuestInteractorTest.java
+++ b/test/use_caseInteractor/GuestInteractorTest.java
@@ -24,4 +24,18 @@ public class GuestInteractorTest {
         guestInteractor = new GuestInteractor(userDataAccessObject, guestOutputBoundary);
     }
 
+    @Test
+    public void testExecute() {
+        // Arrange
+        GuestInputData inputData = new GuestInputData();
+        ArgumentCaptor<GuestOutputData> captor = ArgumentCaptor.forClass(GuestOutputData.class);
+
+        // Act
+        guestInteractor.execute(inputData);
+
+        // Assert
+        verify(guestOutputBoundary).prepareSuccessView(captor.capture());
+        GuestOutputData outputData = captor.getValue();
+
+    }
 }


### PR DESCRIPTION
implemented some tests for the important interface_adapter classes
-CancelControllerTest
-ConsolePresenterTest
-LoginControllerTest

LoginControllerTest was difficult because .getUsername() and .getPassword() were not accessible outside of their package, so in the test sources root I needed to verify that the execute method is called with any instance of LoginInputData. This approach allows us to test the behavior without needing direct access to the private fields. This isn't as rigorous, but I can't think of another way. If you have any other ideas leave a comment.